### PR TITLE
Adding clipboardRead permission

### DIFF
--- a/wx-src/manifest-chrome.json
+++ b/wx-src/manifest-chrome.json
@@ -47,7 +47,7 @@
     "commands" : {
 	"ae-clippings-paste-clipping": {
 	    "suggested_key": {
-		"default": "Ctrl+Shift+Y"
+		"default": "Alt+Shift+Y"
 	    },
 	    "description": "Paste a clipping using its shortcut key"
 	}

--- a/wx-src/manifest.json
+++ b/wx-src/manifest.json
@@ -55,7 +55,7 @@
     "commands" : {
 	"ae-clippings-paste-clipping": {
 	    "suggested_key": {
-		"default": "Ctrl+Shift+Y"
+		"default": "Alt+Shift+Y"
 	    },
 	    "description": "Paste a clipping using its shortcut key"
 	}

--- a/wx-src/manifest.json
+++ b/wx-src/manifest.json
@@ -20,7 +20,8 @@
 	"storage",
 	"history",
 	"tabs",
-	"unlimitedStorage"
+	"unlimitedStorage",
+	"clipboardRead"
     ],
     
     "background": {


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Interact_with_the_clipboard#Reading_from_the_clipboard) 
"You can use the "cut" and "copy" commands without any special permission..."
but
"To use the "paste" command, you must have the "clipboardRead" permission"

Adding this allows pasting from the contextual menu.