### PR TITLE
Updates handleRequestInsertClipping to allow for shadowdom

### DIFF
--- a/wx-src/content.js
+++ b/wx-src/content.js
@@ -106,6 +106,11 @@ function handleRequestInsertClipping(aRequest)
   let htmlPaste = aRequest.htmlPaste;
   let autoLineBrk = aRequest.autoLineBreak;
   let activeElt = window.document.activeElement;
+  
+   // If element uses shadowDom, then we will pull the active element from shadowDom
+   if (!!activeElt.shadowRoot) {
+    activeElt = activeElt.shadowRoot.activeElement
+  }
 
   log("Clippings/wx::content.js: handleRequestInsertClipping(): activeElt = " + (activeElt ? activeElt.toString() : "???"));  
 


### PR DESCRIPTION
When we get the active element, if that element is within shadowdom, we must get the active element within the shadow dom. This fix checks to see if the shadowRoot exists as a property of the element and then updates activeElt to the activeElement in the shadow root.

Tested in firefox using both shadow dom and non shadow dom.