### PR TITLE
adds shadowdom support

### DIFF
--- a/wx-src/content.js
+++ b/wx-src/content.js
@@ -22,7 +22,7 @@ function handleRequestNewClipping(aRequest)
     return rv;
   }
 
-  let activeElt = window.document.activeElement;
+  let activeElt = getActiveElt();
 
   log("Clippings/wx::content.js: handleRequestNewClipping(): activeElt = " + (activeElt ? activeElt.toString() : "???"));
 
@@ -105,7 +105,7 @@ function handleRequestInsertClipping(aRequest)
   let clippingText = aRequest.content;
   let htmlPaste = aRequest.htmlPaste;
   let autoLineBrk = aRequest.autoLineBreak;
-  let activeElt = window.document.activeElement;
+  let activeElt = getActiveElt();
 
   log("Clippings/wx::content.js: handleRequestInsertClipping(): activeElt = " + (activeElt ? activeElt.toString() : "???"));  
 
@@ -240,6 +240,16 @@ function isGoogleChrome()
   rv = ("version_name" in extManifest);
   
   return rv;
+}
+
+function getActiveElt() {
+  let activeElt = window.document.activeElement;
+
+  if (!!activeElt && !!activeElt.shadowRoot) {
+    activeElt = activeElt.shadowRoot.activeElement;
+  }
+  
+  return activeElt;
 }
 
 


### PR DESCRIPTION
### Summary
When you lookup activeElement on the document, it will return the shadowRoot element if the active element is inside a shadowDom. This change adds a common function that checks to see if the `document.activeElement` has a tuthy value for the shadowRoot property returns the activeElement of the shadowRoot if it does. 

### Testing
* validated shadowdom text area
* validated shadowdom input
* validated normal input
* validated normal text area